### PR TITLE
feat: add auction statistics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ $ docker-compose up --build
 $ docker-compose up 
 ```
 
-Both of these methods serve the application over [https://localhost:3000](local deployment)
+Both of these methods serve the application over https://localhost:3000
 
-Remote URL: [https://auction-api-2-bwjwsipn3a-uc.a.run.app](Remote Deployment)
-Postman Documentation: [https://documenter.getpostman.com/view/778610/2sA35Bc519](Docs)
+Remote URL: https://auction-api-2-bwjwsipn3a-uc.a.run.app
+Postman Documentation: https://documenter.getpostman.com/view/778610/2sA35Bc519
 
 ## License
 

--- a/src/http/api/v1/auction/controllers/auction.controllers.ts
+++ b/src/http/api/v1/auction/controllers/auction.controllers.ts
@@ -44,6 +44,16 @@ export class AuctionController extends BaseAppController {
     return this.getHttpResponse().setDataWithKey('data', result).send(res);
   }
 
+  @Get(':auction_id/statistics')
+  async getAuctionStatistics(
+    @Param('auction_id') auction_id: string,
+    @Req() req: AuthRequest,
+    @Res() res: Response,
+  ): Promise<any> {
+    const result = await this.auctionService.getAuctionStatistics(auction_id);
+    return this.getHttpResponse().setDataWithKey('data', result).send(res);
+  }
+
   @Post(':auction_id/end')
   async endAuction(
     @Param('auction_id') auction_id: string,

--- a/src/http/api/v1/auction/services/auction.service.ts
+++ b/src/http/api/v1/auction/services/auction.service.ts
@@ -6,6 +6,7 @@ import { ResponseMessages } from 'src/constants/ResponseMessages';
 import { ServerAppException } from 'src/shared/exceptions/ServerAppException';
 import {
   AuctionContract,
+  AuctionStatistics,
   AuctionStatus,
   TransactionSender,
 } from 'src/shared/types/auction.types';
@@ -67,6 +68,37 @@ export class AuctionService {
       abi,
       address,
     ) as unknown as AuctionContract;
+  }
+
+  async getAuctionStatistics(auction_id: string): Promise<AuctionStatistics> {
+    try {
+      const total_volume = await this.prisma.history.count({
+        where: {
+          auction_id,
+        },
+      });
+
+      const bids = await this.prisma.history.findMany({
+        where: {
+          auction_id,
+        },
+        select: {
+          bid: true,
+        },
+      });
+
+      const total_value = bids.reduce(
+        (total, bid) => total + parseFloat(bid.bid),
+        0,
+      );
+
+      return { total_value, total_volume };
+    } catch (e) {
+      if (e instanceof BaseAppException) {
+        throw e;
+      }
+      throw new ServerAppException(ResponseMessages.SOMETHING_WENT_WRONG, e);
+    }
   }
 
   async getSenderInfo(): Promise<TransactionSender> {

--- a/src/shared/types/auction.types.ts
+++ b/src/shared/types/auction.types.ts
@@ -22,6 +22,11 @@ export interface TransactionSender {
   gasPrice?: string;
 }
 
+export interface AuctionStatistics {
+  total_value: number;
+  total_volume: number;
+}
+
 export interface AuctionContract {
   methods: {
     bid(wallet: string): any;


### PR DESCRIPTION
### Summary

In this PR, I added the controller and service for fetching an auction's statistics. For now it is a simple query to fetch the total number of bids and the sum of all bids. It doesn't take into account withdrawn bids, this functionality can be added later on. I also did some light cleanups on the Readme.md to clean the URLs

- Added Auction Statistics Endpoint
- Created AuctionStatistics interface
- Cleanup Readme.md